### PR TITLE
Assume all stereo JackTrip clients are sending stereo!

### DIFF
--- a/jacktrip_pypatcher.py
+++ b/jacktrip_pypatcher.py
@@ -308,7 +308,7 @@ def main(dry_run = False):
   # TODO: move this to command-line option / config file
   jacktrip_stereo = []
 
-  jacktrip_clients_stereo = list(map(lambda x: x in jacktrip_stereo, jacktrip_clients))
+  jacktrip_clients_stereo = list(map(lambda x: True, jacktrip_clients))
 
   autopatch(jackClient, dry_run, jacktrip_clients, jacktrip_clients_stereo)
 

--- a/test_jacktrip_pypatcher.py
+++ b/test_jacktrip_pypatcher.py
@@ -15,7 +15,7 @@ def run_pypatcher_voice_count(number_of_voices):
   jacktrip_clients = jacktrip_clients[0:number_of_voices]
 
   jacktrip_stereo = jacktrip_clients[0:1]
-  jacktrip_clients_stereo = list(map(lambda x: x in jacktrip_stereo, jacktrip_clients))
+  jacktrip_clients_stereo = list(map(lambda x: True, jacktrip_clients))
 
   # TODO: hacky way to use pytest - we know this assertion will fail, but at the moment
   # we can just inspect the stdout


### PR DESCRIPTION
* previously we assumed people would send mono on channel 1 and silence on channel 2
* now assume that they send the same mono signal on both channels
* if we want to keep this, we can remove quite a bit of boilerplate around this