### PR TITLE
Gain down ladspa plugins

### DIFF
--- a/ladspa_plugins.py
+++ b/ladspa_plugins.py
@@ -61,7 +61,7 @@ def generate_subprocess_cmd(panning_position):
           "-j",
           port_name,
           "-i",
-          "0:0:0:" + str(panning_position) + ":0:0",
+          "0:0:-2:" + str(panning_position) + ":0:0",
           "/usr/lib/ladspa/inv_input.so",
           "3301",
           ]


### PR DESCRIPTION
We can gain down ladspa plugins in order to minimize the chance of distortion occurring when multiple client audio is combined into one mix. The range is -24 - +24. I'm testing here to find a good setting.