### PR TITLE
Implement dry_run in lounge music

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,4 +18,4 @@ jobs:
         python -m pip install --upgrade pip
         pip install -r requirements.txt
     - run: python -m black --check .
-    - run: python -m pytest test_ladspa_plugins.py test_stereo_recording.py test_jacktrip_pypatcher.py
+    - run: python -m pytest test_ladspa_plugins.py test_stereo_recording.py test_jacktrip_pypatcher.py test_lounge_music.py

--- a/jacktrip_pypatcher.py
+++ b/jacktrip_pypatcher.py
@@ -56,7 +56,7 @@ def autopatch(jackClient, dry_run, jacktrip_clients):
         0.75,
     ]
 
-    lounge_music = LoungeMusic(jackClient, "lounge-music", "/home/sam/lounge-music.mp3")
+    lounge_music = LoungeMusic(jackClient, "lounge-music", "/home/sam/lounge-music.mp3", dry_run)
     stereo_recording = StereoRecording("/home/sam/darkice-", dry_run)
     darkice = Darkice(jackClient, "darkice", dry_run)
     ladspa = LadspaPlugins(

--- a/jacktrip_pypatcher.py
+++ b/jacktrip_pypatcher.py
@@ -56,7 +56,9 @@ def autopatch(jackClient, dry_run, jacktrip_clients):
         0.75,
     ]
 
-    lounge_music = LoungeMusic(jackClient, "lounge-music", "/home/sam/lounge-music.mp3", dry_run)
+    lounge_music = LoungeMusic(
+        jackClient, "lounge-music", "/home/sam/lounge-music.mp3", dry_run
+    )
     stereo_recording = StereoRecording("/home/sam/darkice-", dry_run)
     darkice = Darkice(jackClient, "darkice", dry_run)
     ladspa = LadspaPlugins(

--- a/lounge_music.py
+++ b/lounge_music.py
@@ -51,7 +51,7 @@ class LoungeMusic(object):
             return
 
         print("Start the lounge music please!")
-        retry_count = 3
+        retry_count = 0
 
         while port_count == 0 and retry_count < retries:
             retry_count += 1

--- a/lounge_music.py
+++ b/lounge_music.py
@@ -53,7 +53,7 @@ class LoungeMusic(object):
         print("Start the lounge music please!")
         retry_count = 3
 
-        while port_count == 0:
+        while port_count == 0 and retry_count < retries:
             retry_count += 1
             subprocess.Popen(self.get_command())
             time.sleep(0.5)

--- a/lounge_music.py
+++ b/lounge_music.py
@@ -37,26 +37,28 @@ class LoungeMusic(object):
 
         return ports
 
+    def start_the_music(self):
+        if self.dry_run:
+            print("Start lounge music!")
+            return
+        subprocess.Popen(self.get_command())
+        time.sleep(0.5)
+
     def start_the_music_with_retries(self, retries=3):
         """start looping the hold music, if it isn't already playing"""
 
-        if self.dry_run:
-            print("Start lounge music with", retries, "retries")
-            return
-
+        print("Start lounge music with", retries, "retries")
         port_count = len(self.get_all_ports())
 
         if port_count > 0:
             print("Lounge music already playing!")
             return
 
-        print("Start the lounge music please!")
         retry_count = 0
 
         while port_count == 0 and retry_count < retries:
             retry_count += 1
-            subprocess.Popen(self.get_command())
-            time.sleep(0.5)
+            self.start_the_music()
             port_count = len(self.get_all_ports())
 
         if port_count == 0:

--- a/lounge_music.py
+++ b/lounge_music.py
@@ -37,6 +37,8 @@ class LoungeMusic(object):
     def start_the_music_with_retries(self, retries=3):
         """start looping the hold music, if it isn't already playing"""
 
+        port_count = len(self.get_all_ports())
+
         if self.dry_run:
             print("Start lounge music with", retries, "retries")
             return
@@ -47,7 +49,6 @@ class LoungeMusic(object):
 
         print("Start the lounge music please!")
 
-        port_count = len(self.get_all_ports())
         retry_count = 3
 
         while port_count == 0:
@@ -64,11 +65,13 @@ class LoungeMusic(object):
     def kill_the_music(self):
         """kill the hold music, if it's playing"""
 
+        no_of_ports = len(self.get_all_ports())
+
         if self.dry_run:
             print("Kill the music")
             return
 
-        if len(self.get_all_ports()) == 0:
+        if no_of_ports == 0:
             print("Lounge music is not playing!")
             return
         else:

--- a/lounge_music.py
+++ b/lounge_music.py
@@ -28,27 +28,29 @@ class LoungeMusic(object):
 
     def get_all_ports(self):
         """Return all lounge_music ports"""
+
+        ports = self.jackClient.get_ports(self.port + ".*")
+
         if self.dry_run:
             print("Called lounge_music.get_all_ports()")
-            print("Response:", self.jackClient.get_ports(self.port + ".*"))
+            print("Response:", ports)
 
-        return self.jackClient.get_ports(self.port + ".*")
+        return ports
 
     def start_the_music_with_retries(self, retries=3):
         """start looping the hold music, if it isn't already playing"""
-
-        port_count = len(self.get_all_ports())
 
         if self.dry_run:
             print("Start lounge music with", retries, "retries")
             return
 
-        if len(self.get_all_ports()) > 0:
+        port_count = len(self.get_all_ports())
+
+        if port_count > 0:
             print("Lounge music already playing!")
             return
 
         print("Start the lounge music please!")
-
         retry_count = 3
 
         while port_count == 0:
@@ -65,11 +67,11 @@ class LoungeMusic(object):
     def kill_the_music(self):
         """kill the hold music, if it's playing"""
 
-        no_of_ports = len(self.get_all_ports())
-
         if self.dry_run:
             print("Kill the music")
             return
+
+        no_of_ports = len(self.get_all_ports())
 
         if no_of_ports == 0:
             print("Lounge music is not playing!")

--- a/lounge_music.py
+++ b/lounge_music.py
@@ -6,12 +6,12 @@ import time
 class LoungeMusic(object):
     """Lounge music patching stuff"""
 
-    def __init__(self, jackClient, port, file_path):
+    def __init__(self, jackClient, port, file_path, dry_run):
         super(LoungeMusic, self).__init__()
         self.jackClient = jackClient
         self.port = port
         self.file_path = file_path
-        self.debug = False
+        self.dry_run = dry_run
 
     def get_command(self):
         """Get the command to start mpg123"""
@@ -28,43 +28,50 @@ class LoungeMusic(object):
 
     def get_all_ports(self):
         """Return all lounge_music ports"""
+        if self.dry_run:
+            print("Called lounge_music.get_all_ports()")
+            print("Response:", self.jackClient.get_ports(self.port + ".*"))
+
         return self.jackClient.get_ports(self.port + ".*")
 
-    def start_the_music_with_retries(self, retries=3, debug=True):
+    def start_the_music_with_retries(self, retries=3):
         """start looping the hold music, if it isn't already playing"""
 
-        if len(self.get_all_ports()) > 0:
-            if debug:
-                print("Lounge music already playing!")
+        if self.dry_run:
+            print("Start lounge music with", retries, "retries")
             return
 
-        if debug:
-            print("Start the lounge music please!")
+        if len(self.get_all_ports()) > 0:
+            print("Lounge music already playing!")
+            return
+
+        print("Start the lounge music please!")
 
         port_count = len(self.get_all_ports())
         retry_count = 3
 
         while port_count == 0:
-            if retry_count == retries:
-                print("Loung music could not start!")
-                break
             retry_count += 1
             subprocess.Popen(self.get_command())
             time.sleep(0.5)
             port_count = len(self.get_all_ports())
 
-        if debug:
-            print(len(self.get_all_ports()))
+        if port_count == 0:
+            print("WARNING: Could not start lounge music")
+        else:
+            print("Lounge music started")
 
-    def kill_the_music(self, debug=True):
+    def kill_the_music(self):
         """kill the hold music, if it's playing"""
 
-        if len(self.get_all_ports()) == 0:
-            if debug:
-                print("Lounge music is not playing!")
+        if self.dry_run:
+            print("Kill the music")
             return
 
-        if debug:
+        if len(self.get_all_ports()) == 0:
+            print("Lounge music is not playing!")
+            return
+        else:
             print("Kill the lounge music please!")
 
         for proc in psutil.process_iter():
@@ -74,6 +81,3 @@ class LoungeMusic(object):
                     proc.terminate()
 
         time.sleep(0.1)
-
-        if debug:
-            print(len(self.get_all_ports()))

--- a/test_jacktrip_pypatcher.py
+++ b/test_jacktrip_pypatcher.py
@@ -30,9 +30,9 @@ def run_pypatcher_voice_count(number_of_voices):
     # Nb. this won't test the logic of the patching, but may be useful as some kind
     # of integration test to check for other issues
     jacktrip_pypatcher.autopatch(jackClient, dry_run, jacktrip_clients)
-    assert jackClient.get_ports.call_count == 6
+    assert jackClient.get_ports.call_count == 4
     # This is going to test the last set of parameters passed to the function
-    jackClient.get_ports.assert_called_with("lounge-music.*")
+    jackClient.get_ports.assert_called_with("ladspa-.*")
 
 
 # TODO: when we have actual tests, we can use a loop here

--- a/test_lounge_music.py
+++ b/test_lounge_music.py
@@ -1,6 +1,7 @@
 from unittest.mock import Mock
 from lounge_music import LoungeMusic
 
+
 def test_start_the_music_with_retries():
     jackClient = Mock(spec=["get_ports"])
     jackClient.get_ports.return_value = []

--- a/test_lounge_music.py
+++ b/test_lounge_music.py
@@ -1,0 +1,15 @@
+from unittest.mock import Mock
+from lounge_music import LoungeMusic
+
+def test_start_the_music_with_retries():
+    jackClient = Mock(spec=["get_ports"])
+    jackClient.get_ports.return_value = []
+    dry_run = True
+    lounge_music = LoungeMusic(
+        jackClient, "lounge-music", "/home/sam/lounge-music.mp3", dry_run
+    )
+
+    lounge_music.start_the_music_with_retries()
+    assert jackClient.get_ports.call_count == 4
+    # This is going to test the last set of parameters passed to the function
+    jackClient.get_ports.assert_called_with("lounge-music.*")


### PR DESCRIPTION
This involved two changes:

- remove debug mode
- implement dry_run

We could have both of these if it's important, but as this was the only module with a `debug` flag I thought it was ok to remove and add implement dry_run.