### PR TITLE
Refactor 2 & 3 client patching

### DIFF
--- a/jack_client_patching.py
+++ b/jack_client_patching.py
@@ -70,13 +70,13 @@ class JackClientPatching:
         self.client_connections.append((receive, send))
 
     def set_one_to_one_ladspa_connection(self, receive, ladspa_port, send):
-        """append one connection between JackTrip clients"""
+        """append one ladspa connection between JackTrip clients"""
 
         self.connections_to_ladspa.append((receive, ladspa_port))
         self.connections_from_ladspa.append((ladspa_port, send))
 
     def set_one_to_many_ladspa_connections(self, one_receive, ladspa_port, many_sends):
-        """append one-to-many connections between JackTrip clients"""
+        """append one-to-many ladspa connections between JackTrip clients"""
 
         self.connections_to_ladspa.append((one_receive, ladspa_port))
         for send in many_sends:

--- a/jack_client_patching.py
+++ b/jack_client_patching.py
@@ -149,22 +149,6 @@ class JackClientPatching:
 
         self.connect_ports(mpg123 + ":.*", send + ":send_.*")
 
-    def connect_to_left(self, receive, send):
-        """connect receive port/s to left send"""
-        if self.dry_run:
-            print("Connect left", receive, "to", send)
-            return
-
-        self.connect_ports(receive + ":receive_.*", send + ":send_1")
-
-    def connect_to_right(self, receive, send):
-        """connect receive port/s to right send"""
-        if self.dry_run:
-            print("Connect right", receive, "to", send)
-            return
-
-        self.connect_ports(receive + ":receive_.*", send + ":send_.*")
-
     def connect_to_ladspa(self, receive, ladspa):
         """connect receive port/s to a ladspa plugin"""
         if self.dry_run:
@@ -187,23 +171,6 @@ class JackClientPatching:
             return
 
         self.connect_ports(receive + ":receive_.*", send + ".*")
-
-    def connect_darkice_to_left(self, receive, send):
-
-        """connect pair of receive ports to the send ports, left panned"""
-        if self.dry_run:
-            print("Connect left", receive, "to", send)
-            return
-
-        self.connect_ports(receive + ":receive_.*", send + ":left")
-
-    def connect_darkice_to_right(self, receive, send):
-        """connect pair of receive ports to the send ports, right panned"""
-        if self.dry_run:
-            print("Connect right", receive, "to", send)
-            return
-
-        self.connect_ports(receive + ":receive_.*", send + ":right")
 
     def connect_darkice_from_ladspa(self, ladspa, send):
         """connect a ladspa plugin to a pair of send ports"""

--- a/jack_client_patching.py
+++ b/jack_client_patching.py
@@ -87,15 +87,27 @@ class JackClientPatching:
 
         if len(jacktrip_clients) == 2:
 
-            self.set_one_to_one_client_connection(jacktrip_clients[0], jacktrip_clients[1])
-            self.set_one_to_one_client_connection(jacktrip_clients[1], jacktrip_clients[0])
+            self.set_one_to_one_client_connection(
+                jacktrip_clients[0], jacktrip_clients[1]
+            )
+            self.set_one_to_one_client_connection(
+                jacktrip_clients[1], jacktrip_clients[0]
+            )
 
         if len(jacktrip_clients) == 3:
 
-            self.set_one_to_one_ladspa_connection(jacktrip_clients[1], ladspa_ports[0], jacktrip_clients[0])
-            self.set_one_to_one_ladspa_connection(jacktrip_clients[1], ladspa_ports[1], jacktrip_clients[2])
-            self.set_one_to_many_ladspa_connections(jacktrip_clients[0], ladspa_ports[2], jacktrip_clients[1:])
-            self.set_one_to_many_ladspa_connections(jacktrip_clients[2], ladspa_ports[3], jacktrip_clients[:2])
+            self.set_one_to_one_ladspa_connection(
+                jacktrip_clients[1], ladspa_ports[0], jacktrip_clients[0]
+            )
+            self.set_one_to_one_ladspa_connection(
+                jacktrip_clients[1], ladspa_ports[1], jacktrip_clients[2]
+            )
+            self.set_one_to_many_ladspa_connections(
+                jacktrip_clients[0], ladspa_ports[2], jacktrip_clients[1:]
+            )
+            self.set_one_to_many_ladspa_connections(
+                jacktrip_clients[2], ladspa_ports[3], jacktrip_clients[:2]
+            )
 
         if len(jacktrip_clients) > 3:
 
@@ -105,7 +117,9 @@ class JackClientPatching:
                     if jacktrip_client == jacktrip_clients[i]:
                         continue
                     else:
-                        self.connections_from_ladspa.append((ladspa_port, jacktrip_client))
+                        self.connections_from_ladspa.append(
+                            (ladspa_port, jacktrip_client)
+                        )
 
     def make_all_connections(self):
         if self.dry_run:

--- a/jack_client_patching.py
+++ b/jack_client_patching.py
@@ -64,23 +64,23 @@ class JackClientPatching:
         except Exception as e:
             print("Error connecting ports:", e)
 
-    def set_one_to_one_client_connection(self, send, receive):
+    def set_one_to_one_client_connection(self, receive, send):
         """append one connection between JackTrip clients"""
 
-        self.client_connections.append((send, receive))
+        self.client_connections.append((receive, send))
 
-    def set_one_to_one_ladspa_connection(self, send, ladspa_port, receive):
+    def set_one_to_one_ladspa_connection(self, receive, ladspa_port, send):
         """append one connection between JackTrip clients"""
 
-        self.connections_to_ladspa.append((send, ladspa_port))
-        self.connections_from_ladspa.append((ladspa_port, receive))
+        self.connections_to_ladspa.append((receive, ladspa_port))
+        self.connections_from_ladspa.append((ladspa_port, send))
 
-    def set_one_to_many_ladspa_connections(self, one_send, ladspa_port, many_receives):
+    def set_one_to_many_ladspa_connections(self, one_receive, ladspa_port, many_sends):
         """append one-to-many connections between JackTrip clients"""
 
-        self.connections_to_ladspa.append((one_send, ladspa_port))
-        for receive in many_receives:
-            self.connections_from_ladspa.append((ladspa_port, receive))
+        self.connections_to_ladspa.append((one_receive, ladspa_port))
+        for send in many_sends:
+            self.connections_from_ladspa.append((ladspa_port, send))
 
     def set_all_connections(self, jacktrip_clients, ladspa_ports=[]):
         """make list of all connections between JackTrip clients & ladspa ports"""

--- a/jacktrip_pypatcher.py
+++ b/jacktrip_pypatcher.py
@@ -56,7 +56,9 @@ def autopatch(jackClient, dry_run, jacktrip_clients):
         0.75,
     ]
 
-    lounge_music = LoungeMusic(jackClient, "lounge-music", "/home/sam/lounge-music.mp3", dry_run)
+    lounge_music = LoungeMusic(
+        jackClient, "lounge-music", "/home/sam/lounge-music.mp3", dry_run
+    )
     stereo_recording = StereoRecording("/home/sam/darkice-", dry_run)
     darkice = Darkice(jackClient, "darkice", dry_run)
     ladspa = LadspaPlugins(

--- a/jacktrip_pypatcher.py
+++ b/jacktrip_pypatcher.py
@@ -116,49 +116,29 @@ def autopatch(jackClient, dry_run, jacktrip_clients):
 
     if len(jacktrip_clients) == 2 or len(jacktrip_clients) == 3:
 
-        panning_positions = ladspa.get_panning_positions(len(jacktrip_clients))
-
-        # ports needed for 2 & 3 client sessions
-        # if we like this method we can add the positions to all_panning_positions
-        ladspa_mid_left_1 = ladspa.get_port(panning_positions[0], all_ladspa_ports)
-        ladspa_mid_left_2 = ladspa.get_port(panning_positions[1], all_ladspa_ports)
-        ladspa_mid_right_1 = ladspa.get_port(panning_positions[2], all_ladspa_ports)
-        ladspa_mid_right_2 = ladspa.get_port(panning_positions[3], all_ladspa_ports)
+        ladspa_ports = ladspa.get_ports(len(jacktrip_clients), all_ladspa_ports)
 
     if len(jacktrip_clients) == 2:
 
-        jcp.connect_to_centre(jacktrip_clients[1], jacktrip_clients[0])
-        jcp.connect_to_centre(jacktrip_clients[0], jacktrip_clients[1])
+        jcp.set_all_connections(jacktrip_clients, ladspa_ports)
+        jcp.make_all_connections()
 
         print("-- darkice --")
-        jcp.connect_to_ladspa(jacktrip_clients[0], ladspa_mid_left_1)
-        jcp.connect_to_ladspa(jacktrip_clients[1], ladspa_mid_right_2)
+        jcp.connect_to_ladspa(jacktrip_clients[0], ladspa_ports[0])
+        jcp.connect_to_ladspa(jacktrip_clients[1], ladspa_ports[1])
 
-        jcp.connect_darkice_from_ladspa(ladspa_mid_left_1, darkice_port)
-        jcp.connect_darkice_from_ladspa(ladspa_mid_right_2, darkice_port)
+        jcp.connect_darkice_from_ladspa(ladspa_ports[0], darkice_port)
+        jcp.connect_darkice_from_ladspa(ladspa_ports[1], darkice_port)
 
     if len(jacktrip_clients) == 3:
-        # Connections for 3 clients are a bit special as we need to make sure the L-R
-        # balance for each client is even (not two peers in one channel)
-
-        jcp.connect_to_ladspa(jacktrip_clients[1], ladspa_mid_left_1)
-        jcp.connect_to_ladspa(jacktrip_clients[1], ladspa_mid_right_1)
-        jcp.connect_to_ladspa(jacktrip_clients[0], ladspa_mid_left_2)
-        jcp.connect_to_ladspa(jacktrip_clients[2], ladspa_mid_right_2)
-
-        jcp.connect_from_ladspa(ladspa_mid_left_1, jacktrip_clients[0])
-        jcp.connect_from_ladspa(ladspa_mid_right_2, jacktrip_clients[0])
-
-        jcp.connect_from_ladspa(ladspa_mid_left_2, jacktrip_clients[1])
-        jcp.connect_from_ladspa(ladspa_mid_right_2, jacktrip_clients[1])
-
-        jcp.connect_from_ladspa(ladspa_mid_left_2, jacktrip_clients[2])
-        jcp.connect_from_ladspa(ladspa_mid_right_1, jacktrip_clients[2])
 
         print("-- darkice --")
 
-        jcp.connect_darkice_from_ladspa(ladspa_mid_left_2, darkice_port)
-        jcp.connect_darkice_from_ladspa(ladspa_mid_right_2, darkice_port)
+        jcp.set_all_connections(jacktrip_clients, ladspa_ports)
+        jcp.make_all_connections()
+
+        jcp.connect_darkice_from_ladspa(ladspa_ports[2], darkice_port)
+        jcp.connect_darkice_from_ladspa(ladspa_ports[3], darkice_port)
         jcp.connect_darkice_to_centre(jacktrip_clients[1], darkice_port)
 
     if len(jacktrip_clients) >= 4 and len(jacktrip_clients) <= 11:

--- a/ladspa_plugins.py
+++ b/ladspa_plugins.py
@@ -13,11 +13,16 @@ class LadspaPlugins(object):
         self.dry_run = dry_run
 
     def get_panning_positions(self, number_of_clients):
-        if number_of_clients == 2 or number_of_clients == 3:
+        if number_of_clients == 2:
             return [
                 self.all_positions[5],
-                (self.all_positions[5] - 0.01),
                 self.all_positions[6],
+            ]
+        if number_of_clients == 3:
+            return [
+                self.all_positions[5],
+                self.all_positions[6],
+                (self.all_positions[5] - 0.01),
                 (self.all_positions[6] + 0.01),
             ]
         if number_of_clients == 4:

--- a/test_jack_client_patching.py
+++ b/test_jack_client_patching.py
@@ -45,6 +45,7 @@ def test_set_all_connections_4_clients():
     assert jcp.connections_to_ladspa == connections_to_ladspa
     assert jcp.connections_from_ladspa == connections_from_ladspa
 
+
 def test_set_all_connections_2_clients():
 
     jackClient = None
@@ -63,6 +64,7 @@ def test_set_all_connections_2_clients():
     jcp.set_one_to_one_client_connection(jacktrip_clients[1], jacktrip_clients[0])
 
     assert jcp.client_connections == client_connections
+
 
 def test_set_all_connections_3_clients():
 

--- a/test_jack_client_patching.py
+++ b/test_jack_client_patching.py
@@ -1,7 +1,7 @@
 import jack_client_patching as p
 
 
-def test_set_all_connections():
+def test_set_all_connections_4_clients():
 
     jackClient = None
     jacktrip_clients = [
@@ -37,6 +37,63 @@ def test_set_all_connections():
         ("ladspa-right-60", "..ffff.192.168.0.1"),
         ("ladspa-right-60", "..ffff.192.168.0.2"),
         ("ladspa-right-60", "..ffff.192.168.0.3"),
+    ]
+
+    jcp = p.JackClientPatching(jackClient, dry_run=True)
+    jcp.set_all_connections(jacktrip_clients, ladspa_ports)
+
+    assert jcp.connections_to_ladspa == connections_to_ladspa
+    assert jcp.connections_from_ladspa == connections_from_ladspa
+
+def test_set_all_connections_2_clients():
+
+    jackClient = None
+    jacktrip_clients = [
+        "..ffff.192.168.0.1",
+        "..ffff.192.168.0.2",
+    ]
+
+    client_connections = [
+        ("..ffff.192.168.0.1", "..ffff.192.168.0.2"),
+        ("..ffff.192.168.0.2", "..ffff.192.168.0.1"),
+    ]
+
+    jcp = p.JackClientPatching(jackClient, dry_run=True)
+    jcp.set_one_to_one_client_connection(jacktrip_clients[0], jacktrip_clients[1])
+    jcp.set_one_to_one_client_connection(jacktrip_clients[1], jacktrip_clients[0])
+
+    assert jcp.client_connections == client_connections
+
+def test_set_all_connections_3_clients():
+
+    jackClient = None
+    jacktrip_clients = [
+        "..ffff.192.168.0.1",
+        "..ffff.192.168.0.2",
+        "..ffff.192.168.0.3",
+    ]
+
+    ladspa_ports = [
+        "ladspa-left-45",
+        "ladspa-right-45",
+        "ladspa-left-46",
+        "ladspa-right-46",
+    ]
+
+    connections_to_ladspa = [
+        ("..ffff.192.168.0.2", "ladspa-left-45"),
+        ("..ffff.192.168.0.2", "ladspa-right-45"),
+        ("..ffff.192.168.0.1", "ladspa-left-46"),
+        ("..ffff.192.168.0.3", "ladspa-right-46"),
+    ]
+
+    connections_from_ladspa = [
+        ("ladspa-left-45", "..ffff.192.168.0.1"),
+        ("ladspa-right-45", "..ffff.192.168.0.3"),
+        ("ladspa-left-46", "..ffff.192.168.0.2"),
+        ("ladspa-left-46", "..ffff.192.168.0.3"),
+        ("ladspa-right-46", "..ffff.192.168.0.1"),
+        ("ladspa-right-46", "..ffff.192.168.0.2"),
     ]
 
     jcp = p.JackClientPatching(jackClient, dry_run=True)

--- a/test_ladspa_plugins.py
+++ b/test_ladspa_plugins.py
@@ -54,7 +54,8 @@ def test_get_panning_positions():
         None, "/home/sam/ng-jackspa/jackspa-cli", all_panning_positions, dry_run=True
     )
 
-    positions_for_2_or_3_clients = [-0.45, -0.46, 0.45, 0.46]
+    positions_for_2_clients = [-0.45, 0.45]
+    positions_for_3_clients = [-0.45, 0.45, -0.46, 0.46]
     positions_for_4_clients = [-0.3, 0.3, -0.45, 0.45]
     positions_for_5_clients = [0, -0.3, 0.3, -0.45, 0.45]
     positions_for_6_clients = [-0.15, 0.15, -0.45, 0.45, -0.6, 0.6]
@@ -64,8 +65,8 @@ def test_get_panning_positions():
     positions_for_10_clients = [-0.15, 0.15, -0.3, 0.3, -0.45, 0.45, -0.6, 0.6, -0.75, 0.75]
     positions_for_11_clients = [0, -0.15, 0.15, -0.3, 0.3, -0.45, 0.45, -0.6, 0.6, -0.75, 0.75]
 
-    assert ladspa.get_panning_positions(2) == positions_for_2_or_3_clients
-    assert ladspa.get_panning_positions(3) == positions_for_2_or_3_clients
+    assert ladspa.get_panning_positions(2) == positions_for_2_clients
+    assert ladspa.get_panning_positions(3) == positions_for_3_clients
     assert ladspa.get_panning_positions(4) == positions_for_4_clients
     assert ladspa.get_panning_positions(5) == positions_for_5_clients
     assert ladspa.get_panning_positions(6) == positions_for_6_clients

--- a/test_ladspa_plugins.py
+++ b/test_ladspa_plugins.py
@@ -35,6 +35,7 @@ def test_generate_port_name():
         ladspa.generate_port_name(position) for position in panning_positions
     ] == port_names
 
+
 def test_get_panning_positions():
 
     all_panning_positions = [
@@ -62,8 +63,31 @@ def test_get_panning_positions():
     positions_for_7_clients = [0, -0.15, 0.15, -0.45, 0.45, -0.6, 0.6]
     positions_for_8_clients = [-0.15, 0.15, -0.3, 0.3, -0.45, 0.45, -0.6, 0.6]
     positions_for_9_clients = [0, -0.15, 0.15, -0.3, 0.3, -0.45, 0.45, -0.6, 0.6]
-    positions_for_10_clients = [-0.15, 0.15, -0.3, 0.3, -0.45, 0.45, -0.6, 0.6, -0.75, 0.75]
-    positions_for_11_clients = [0, -0.15, 0.15, -0.3, 0.3, -0.45, 0.45, -0.6, 0.6, -0.75, 0.75]
+    positions_for_10_clients = [
+        -0.15,
+        0.15,
+        -0.3,
+        0.3,
+        -0.45,
+        0.45,
+        -0.6,
+        0.6,
+        -0.75,
+        0.75,
+    ]
+    positions_for_11_clients = [
+        0,
+        -0.15,
+        0.15,
+        -0.3,
+        0.3,
+        -0.45,
+        0.45,
+        -0.6,
+        0.6,
+        -0.75,
+        0.75,
+    ]
 
     assert ladspa.get_panning_positions(2) == positions_for_2_clients
     assert ladspa.get_panning_positions(3) == positions_for_3_clients
@@ -75,6 +99,7 @@ def test_get_panning_positions():
     assert ladspa.get_panning_positions(9) == positions_for_9_clients
     assert ladspa.get_panning_positions(10) == positions_for_10_clients
     assert ladspa.get_panning_positions(11) == positions_for_11_clients
+
 
 # run pytest with -rP flag to see stdout logs showing which ports need to be started
 def test_get_and_check_port():

--- a/test_ladspa_plugins.py
+++ b/test_ladspa_plugins.py
@@ -35,6 +35,45 @@ def test_generate_port_name():
         ladspa.generate_port_name(position) for position in panning_positions
     ] == port_names
 
+def test_get_panning_positions():
+
+    all_panning_positions = [
+        0,
+        -0.15,
+        0.15,
+        -0.3,
+        0.3,
+        -0.45,
+        0.45,
+        -0.6,
+        0.6,
+        -0.75,
+        0.75,
+    ]
+    ladspa = LadspaPlugins(
+        None, "/home/sam/ng-jackspa/jackspa-cli", all_panning_positions, dry_run=True
+    )
+
+    positions_for_2_or_3_clients = [-0.45, -0.46, 0.45, 0.46]
+    positions_for_4_clients = [-0.3, 0.3, -0.45, 0.45]
+    positions_for_5_clients = [0, -0.3, 0.3, -0.45, 0.45]
+    positions_for_6_clients = [-0.15, 0.15, -0.45, 0.45, -0.6, 0.6]
+    positions_for_7_clients = [0, -0.15, 0.15, -0.45, 0.45, -0.6, 0.6]
+    positions_for_8_clients = [-0.15, 0.15, -0.3, 0.3, -0.45, 0.45, -0.6, 0.6]
+    positions_for_9_clients = [0, -0.15, 0.15, -0.3, 0.3, -0.45, 0.45, -0.6, 0.6]
+    positions_for_10_clients = [-0.15, 0.15, -0.3, 0.3, -0.45, 0.45, -0.6, 0.6, -0.75, 0.75]
+    positions_for_11_clients = [0, -0.15, 0.15, -0.3, 0.3, -0.45, 0.45, -0.6, 0.6, -0.75, 0.75]
+
+    assert ladspa.get_panning_positions(2) == positions_for_2_or_3_clients
+    assert ladspa.get_panning_positions(3) == positions_for_2_or_3_clients
+    assert ladspa.get_panning_positions(4) == positions_for_4_clients
+    assert ladspa.get_panning_positions(5) == positions_for_5_clients
+    assert ladspa.get_panning_positions(6) == positions_for_6_clients
+    assert ladspa.get_panning_positions(7) == positions_for_7_clients
+    assert ladspa.get_panning_positions(8) == positions_for_8_clients
+    assert ladspa.get_panning_positions(9) == positions_for_9_clients
+    assert ladspa.get_panning_positions(10) == positions_for_10_clients
+    assert ladspa.get_panning_positions(11) == positions_for_11_clients
 
 # run pytest with -rP flag to see stdout logs showing which ports need to be started
 def test_get_and_check_port():


### PR DESCRIPTION
This would be the first step in moving all patching logic for 2 -> 11 clients into `jack_client_patching`. Sure there are a few different approaches to this though, how does this look as a basis? After this we could implement logic for the `darkice` connections. ~~Also I imagine refactoring the different connection type methods (client -> ladspa, ladspa -> client, ladspa -> darkice etc..) into one method with a switch and connection_type keys.~~ <-- for another time if at all....

~~BLOCKED: merge #61 first~~