### PR TITLE
Full port strings in set_connection methods

### DIFF
--- a/jack_client_patching.py
+++ b/jack_client_patching.py
@@ -9,8 +9,7 @@ class JackClientPatching:
     def __init__(self, jackClient, dry_run):
         super(JackClientPatching, self).__init__()
         self.jackClient = jackClient
-        self.connections_to_ladspa = []
-        self.connections_from_ladspa = []
+        self.connections = []
         self.dry_run = dry_run
 
     def disconnect_all(self, my_port):
@@ -63,26 +62,35 @@ class JackClientPatching:
         except Exception as e:
             print("Error connecting ports:", e)
 
+    def jacktrip_receive(self, port):
+        return port + ":receive_.*"
+
+    def jacktrip_send(self, port):
+        return port + ":send_.*"
+
+    def ladspa_receive(self, port):
+        return port + ":Output.*"
+
+    def ladspa_send(self, port):
+        return port + ":Input.*"
+
     def set_all_connections(self, jacktrip_clients, ladspa_ports):
         """make list of all connections between JackTrip clients & ladspa ports"""
-        for i, ladspa_port in enumerate(ladspa_ports):
-            self.connections_to_ladspa.append((jacktrip_clients[i], ladspa_port))
+        for i, ladspa in enumerate(ladspa_ports):
+            self.connections.append((self.jacktrip_receive(jacktrip_clients[i]), self.ladspa_send(ladspa)))
             for jacktrip_client in jacktrip_clients:
                 if jacktrip_client == jacktrip_clients[i]:
                     continue
                 else:
-                    self.connections_from_ladspa.append((ladspa_port, jacktrip_client))
+                    self.connections.append((self.ladspa_receive(ladspa), self.jacktrip_send(jacktrip_client)))
 
     def make_all_connections(self):
         if self.dry_run:
-            print("Make connections to ladspa")
-            print(self.connections_to_ladspa)
-            print("Make connections from ladspa")
-            print(self.connections_from_ladspa)
+            print("Make all connections")
+            print(self.connections)
             return
 
-        [self.connect_to_ladspa(c[0], c[1]) for c in self.connections_to_ladspa]
-        [self.connect_from_ladspa(c[0], c[1]) for c in self.connections_from_ladspa]
+        [self.connect_ports(c[0], c[1]) for c in self.connections]
 
     def connect_to_centre(self, receive, send):
         """connect receive port/s to centre send"""

--- a/jack_client_patching.py
+++ b/jack_client_patching.py
@@ -74,22 +74,18 @@ class JackClientPatching:
     def ladspa_send(self, port):
         return port + ":Input.*"
 
-    def set_all_connections(self, jacktrip_clients, ladspa_ports):
+    def set_all_connections(self, jacktrip_ports, ladspa_ports):
         """make list of all connections between JackTrip clients & ladspa ports"""
         for i, ladspa in enumerate(ladspa_ports):
-            self.connections.append(
-                (self.jacktrip_receive(jacktrip_clients[i]), self.ladspa_send(ladspa))
-            )
-            for jacktrip_client in jacktrip_clients:
-                if jacktrip_client == jacktrip_clients[i]:
+            r = self.jacktrip_receive(jacktrip_ports[i])
+            s = self.ladspa_send(ladspa)
+            self.connections.append((r, s))
+            for jacktrip_port in jacktrip_ports:
+                if jacktrip_port == jacktrip_ports[i]:
                     continue
-                else:
-                    self.connections.append(
-                        (
-                            self.ladspa_receive(ladspa),
-                            self.jacktrip_send(jacktrip_client),
-                        )
-                    )
+                r = self.ladspa_receive(ladspa)
+                s = self.jacktrip_send(jacktrip_port)
+                self.connections.append((r, s))
 
     def make_all_connections(self):
         if self.dry_run:

--- a/jack_client_patching.py
+++ b/jack_client_patching.py
@@ -77,15 +77,15 @@ class JackClientPatching:
     def set_all_connections(self, jacktrip_ports, ladspa_ports):
         """make list of all connections between JackTrip clients & ladspa ports"""
         for i, ladspa in enumerate(ladspa_ports):
-            r = self.jacktrip_receive(jacktrip_ports[i])
-            s = self.ladspa_send(ladspa)
-            self.connections.append((r, s))
+            jacktrip_receive = self.jacktrip_receive(jacktrip_ports[i])
+            ladspa_send = self.ladspa_send(ladspa)
+            self.connections.append((jacktrip_receive, ladspa_send))
             for jacktrip_port in jacktrip_ports:
                 if jacktrip_port == jacktrip_ports[i]:
                     continue
-                r = self.ladspa_receive(ladspa)
-                s = self.jacktrip_send(jacktrip_port)
-                self.connections.append((r, s))
+                ladspa_send = self.ladspa_receive(ladspa)
+                jacktrip_receive = self.jacktrip_send(jacktrip_port)
+                self.connections.append((ladspa_send, jacktrip_receive))
 
     def make_all_connections(self):
         if self.dry_run:

--- a/jack_client_patching.py
+++ b/jack_client_patching.py
@@ -83,9 +83,9 @@ class JackClientPatching:
             for jacktrip_port in jacktrip_ports:
                 if jacktrip_port == jacktrip_ports[i]:
                     continue
-                ladspa_send = self.ladspa_receive(ladspa)
-                jacktrip_receive = self.jacktrip_send(jacktrip_port)
-                self.connections.append((ladspa_send, jacktrip_receive))
+                ladspa_receive = self.ladspa_receive(ladspa)
+                jacktrip_send = self.jacktrip_send(jacktrip_port)
+                self.connections.append((ladspa_receive, jacktrip_send))
 
     def make_all_connections(self):
         if self.dry_run:

--- a/jack_client_patching.py
+++ b/jack_client_patching.py
@@ -77,12 +77,19 @@ class JackClientPatching:
     def set_all_connections(self, jacktrip_clients, ladspa_ports):
         """make list of all connections between JackTrip clients & ladspa ports"""
         for i, ladspa in enumerate(ladspa_ports):
-            self.connections.append((self.jacktrip_receive(jacktrip_clients[i]), self.ladspa_send(ladspa)))
+            self.connections.append(
+                (self.jacktrip_receive(jacktrip_clients[i]), self.ladspa_send(ladspa))
+            )
             for jacktrip_client in jacktrip_clients:
                 if jacktrip_client == jacktrip_clients[i]:
                     continue
                 else:
-                    self.connections.append((self.ladspa_receive(ladspa), self.jacktrip_send(jacktrip_client)))
+                    self.connections.append(
+                        (
+                            self.ladspa_receive(ladspa),
+                            self.jacktrip_send(jacktrip_client),
+                        )
+                    )
 
     def make_all_connections(self):
         if self.dry_run:

--- a/test_jack_client_patching.py
+++ b/test_jack_client_patching.py
@@ -17,30 +17,26 @@ def test_set_all_connections():
         "ladspa-right-60",
     ]
 
-    connections_to_ladspa = [
-        ("..ffff.192.168.0.1", "ladspa-left-30"),
-        ("..ffff.192.168.0.2", "ladspa-right-30"),
-        ("..ffff.192.168.0.3", "ladspa-left-60"),
-        ("..ffff.192.168.0.4", "ladspa-right-60"),
-    ]
-
-    connections_from_ladspa = [
-        ("ladspa-left-30", "..ffff.192.168.0.2"),
-        ("ladspa-left-30", "..ffff.192.168.0.3"),
-        ("ladspa-left-30", "..ffff.192.168.0.4"),
-        ("ladspa-right-30", "..ffff.192.168.0.1"),
-        ("ladspa-right-30", "..ffff.192.168.0.3"),
-        ("ladspa-right-30", "..ffff.192.168.0.4"),
-        ("ladspa-left-60", "..ffff.192.168.0.1"),
-        ("ladspa-left-60", "..ffff.192.168.0.2"),
-        ("ladspa-left-60", "..ffff.192.168.0.4"),
-        ("ladspa-right-60", "..ffff.192.168.0.1"),
-        ("ladspa-right-60", "..ffff.192.168.0.2"),
-        ("ladspa-right-60", "..ffff.192.168.0.3"),
+    connections = [
+        ("..ffff.192.168.0.1:receive_.*", "ladspa-left-30:Input.*"),
+        ("ladspa-left-30:Output.*", "..ffff.192.168.0.2:send_.*"),
+        ("ladspa-left-30:Output.*", "..ffff.192.168.0.3:send_.*"),
+        ("ladspa-left-30:Output.*", "..ffff.192.168.0.4:send_.*"),
+        ("..ffff.192.168.0.2:receive_.*", "ladspa-right-30:Input.*"),
+        ("ladspa-right-30:Output.*", "..ffff.192.168.0.1:send_.*"),
+        ("ladspa-right-30:Output.*", "..ffff.192.168.0.3:send_.*"),
+        ("ladspa-right-30:Output.*", "..ffff.192.168.0.4:send_.*"),
+        ("..ffff.192.168.0.3:receive_.*", "ladspa-left-60:Input.*"),
+        ("ladspa-left-60:Output.*", "..ffff.192.168.0.1:send_.*"),
+        ("ladspa-left-60:Output.*", "..ffff.192.168.0.2:send_.*"),
+        ("ladspa-left-60:Output.*", "..ffff.192.168.0.4:send_.*"),
+        ("..ffff.192.168.0.4:receive_.*", "ladspa-right-60:Input.*"),
+        ("ladspa-right-60:Output.*", "..ffff.192.168.0.1:send_.*"),
+        ("ladspa-right-60:Output.*", "..ffff.192.168.0.2:send_.*"),
+        ("ladspa-right-60:Output.*", "..ffff.192.168.0.3:send_.*"),
     ]
 
     jcp = p.JackClientPatching(jackClient, dry_run=True)
     jcp.set_all_connections(jacktrip_clients, ladspa_ports)
 
-    assert jcp.connections_to_ladspa == connections_to_ladspa
-    assert jcp.connections_from_ladspa == connections_from_ladspa
+    assert jcp.connections == connections


### PR DESCRIPTION
This is quite an elegant way to build up the `conections` list I think. Would make it simple to add `darkice` and `lounge-music` connections to the list with tests. I prefer this over https://github.com/noiseorchestra/jacktrip_pypatcher/pull/62.