### PR TITLE
Add xfail test for 3 client patching

### DIFF
--- a/test_jack_client_patching.py
+++ b/test_jack_client_patching.py
@@ -44,3 +44,41 @@ def test_set_all_connections():
 
     assert jcp.connections_to_ladspa == connections_to_ladspa
     assert jcp.connections_from_ladspa == connections_from_ladspa
+
+def test_set_all_connections_3_clients():
+    pytest.xfail("This configuration not currently supported")
+
+    jackClient = None
+    jacktrip_clients = [
+        "..ffff.192.168.0.1",
+        "..ffff.192.168.0.2",
+        "..ffff.192.168.0.3",
+    ]
+    ladspa_ports = [
+        "ladspa-left-45",
+        "ladspa-right-45",
+        "ladspa-left-46",
+        "ladspa-right-46",
+    ]
+
+    connections_to_ladspa = [
+        ("..ffff.192.168.0.1", "ladspa-left-45"),
+        ("..ffff.192.168.0.2", "ladspa-left-46"),
+        ("..ffff.192.168.0.2", "ladspa-right-46"),
+        ("..ffff.192.168.0.3", "ladspa-right-45"),
+    ]
+
+    connections_from_ladspa = [
+        ("ladspa-left-46", "..ffff.192.168.0.1"),
+        ("ladspa-right-45", "..ffff.192.168.0.1"),
+        ("ladspa-left-45", "..ffff.192.168.0.2"),
+        ("ladspa-right-45", "..ffff.192.168.0.2"),
+        ("ladspa-left-45", "..ffff.192.168.0.3"),
+        ("ladspa-right-46", "..ffff.192.168.0.3"),
+    ]
+
+    jcp = p.JackClientPatching(jackClient, dry_run=True)
+    jcp.set_all_connections(jacktrip_clients, ladspa_ports)
+
+    assert jcp.connections_to_ladspa == connections_to_ladspa
+    assert jcp.connections_from_ladspa == connections_from_ladspa

--- a/test_jack_client_patching.py
+++ b/test_jack_client_patching.py
@@ -1,4 +1,5 @@
 import jack_client_patching as p
+import pytest
 
 
 def test_set_all_connections():

--- a/test_jack_client_patching.py
+++ b/test_jack_client_patching.py
@@ -42,6 +42,7 @@ def test_set_all_connections():
 
     assert jcp.connections == connections
 
+
 def test_set_all_connections_3_clients():
     pytest.xfail("This configuration not currently supported")
 

--- a/test_jack_client_patching.py
+++ b/test_jack_client_patching.py
@@ -45,6 +45,7 @@ def test_set_all_connections():
     assert jcp.connections_to_ladspa == connections_to_ladspa
     assert jcp.connections_from_ladspa == connections_from_ladspa
 
+
 def test_set_all_connections_3_clients():
     pytest.xfail("This configuration not currently supported")
 


### PR DESCRIPTION
Another thing we can do is create tests for things that don't work yet, but we can decide how we want them to work. Marked as `xfail` for "expected failure", which means it won't kill the CI run.