### PR TITLE
Move logic for 2 & 3 clients into jcp

### DIFF
--- a/jack_client_patching.py
+++ b/jack_client_patching.py
@@ -74,6 +74,17 @@ class JackClientPatching:
     def ladspa_send(self, port):
         return port + ":Input.*"
 
+    def darkice_send(self, port):
+        return port + ".*"
+
+    def set_darkice_connections(self, ladspa_ports, darkice):
+        """append darkice connections to connections list"""
+        print("-- darkice --")
+        for ladspa in ladspa_ports:
+            self.connections.append(
+                (self.ladspa_receive(ladspa), self.darkice_send(darkice))
+            )
+
     def set_all_connections(self, jacktrip_ports, ladspa_ports):
         """make list of all connections between JackTrip clients & ladspa ports"""
         for i, ladspa in enumerate(ladspa_ports):

--- a/jack_client_patching.py
+++ b/jack_client_patching.py
@@ -97,11 +97,38 @@ class JackClientPatching:
         self.connections.append((jacktrip_receive_1, self.ladspa_send(ladspa_ports[0])))
         self.connections.append((jacktrip_receive_2, self.ladspa_send(ladspa_ports[1])))
 
+    def set_connections_3_clients(self, jacktrip_ports, ladspa_ports):
+
+        jacktrip_receive_1 = self.jacktrip_receive(jacktrip_ports[0])
+        jacktrip_receive_2 = self.jacktrip_receive(jacktrip_ports[1])
+        jacktrip_receive_3 = self.jacktrip_receive(jacktrip_ports[2])
+        jacktrip_send_1 = self.jacktrip_send(jacktrip_ports[0])
+        jacktrip_send_2 = self.jacktrip_send(jacktrip_ports[1])
+        jacktrip_send_3 = self.jacktrip_send(jacktrip_ports[2])
+
+        for ladspa_port in ladspa_ports[0:3]:
+            self.connections.append(jacktrip_receive_1, self.ladspa_send(ladspa_port))
+
+        self.connections.append(jacktrip_receive_2, self.ladspa_send(ladspa_ports[3]))
+        self.connections.append(jacktrip_receive_3, self.ladspa_send(ladspa_ports[4]))
+
+        self.connections.append(self.ladspa_receive(ladspa_ports[3]), jacktrip_send_1)
+        self.connections.append(self.ladspa_receive(ladspa_ports[4]), jacktrip_send_1)
+
+        self.connections.append(self.ladspa_receive(ladspa_ports[1]), jacktrip_send_2)
+        self.connections.append(self.ladspa_receive(ladspa_ports[4]), jacktrip_send_2)
+
+        self.connections.append(self.ladspa_receive(ladspa_ports[3]), jacktrip_send_3)
+        self.connections.append(self.ladspa_receive(ladspa_ports[2]), jacktrip_send_3)
+
     def set_all_connections(self, jacktrip_ports, ladspa_ports):
         """append all connections between JackTrip clients & ladspa ports"""
 
         if len(jacktrip_ports) == 2:
             self.set_connections_2_clients(jacktrip_ports, ladspa_ports)
+
+        if len(jacktrip_ports) == 3:
+            self.set_connections_3_clients(jacktrip_ports, ladspa_ports)
 
         if len(jacktrip_ports) > 3:
             for i, ladspa in enumerate(ladspa_ports):

--- a/jack_client_patching.py
+++ b/jack_client_patching.py
@@ -107,19 +107,19 @@ class JackClientPatching:
         jacktrip_send_3 = self.jacktrip_send(jacktrip_ports[2])
 
         for ladspa_port in ladspa_ports[0:3]:
-            self.connections.append(jacktrip_receive_1, self.ladspa_send(ladspa_port))
+            self.connections.append((jacktrip_receive_1, self.ladspa_send(ladspa_port)))
 
-        self.connections.append(jacktrip_receive_2, self.ladspa_send(ladspa_ports[3]))
-        self.connections.append(jacktrip_receive_3, self.ladspa_send(ladspa_ports[4]))
+        self.connections.append((jacktrip_receive_2, self.ladspa_send(ladspa_ports[3])))
+        self.connections.append((jacktrip_receive_3, self.ladspa_send(ladspa_ports[4])))
 
-        self.connections.append(self.ladspa_receive(ladspa_ports[3]), jacktrip_send_1)
-        self.connections.append(self.ladspa_receive(ladspa_ports[4]), jacktrip_send_1)
+        self.connections.append((self.ladspa_receive(ladspa_ports[3]), jacktrip_send_1))
+        self.connections.append((self.ladspa_receive(ladspa_ports[4]), jacktrip_send_1))
 
-        self.connections.append(self.ladspa_receive(ladspa_ports[1]), jacktrip_send_2)
-        self.connections.append(self.ladspa_receive(ladspa_ports[4]), jacktrip_send_2)
+        self.connections.append((self.ladspa_receive(ladspa_ports[1]), jacktrip_send_2))
+        self.connections.append((self.ladspa_receive(ladspa_ports[4]), jacktrip_send_2))
 
-        self.connections.append(self.ladspa_receive(ladspa_ports[3]), jacktrip_send_3)
-        self.connections.append(self.ladspa_receive(ladspa_ports[2]), jacktrip_send_3)
+        self.connections.append((self.ladspa_receive(ladspa_ports[3]), jacktrip_send_3))
+        self.connections.append((self.ladspa_receive(ladspa_ports[2]), jacktrip_send_3))
 
     def set_all_connections(self, jacktrip_ports, ladspa_ports):
         """append all connections between JackTrip clients & ladspa ports"""

--- a/jack_client_patching.py
+++ b/jack_client_patching.py
@@ -85,18 +85,35 @@ class JackClientPatching:
                 (self.ladspa_receive(ladspa), self.darkice_send(darkice))
             )
 
+    def set_connections_2_clients(self, jacktrip_ports, ladspa_ports):
+
+        jacktrip_receive_1 = self.jacktrip_receive(jacktrip_ports[0])
+        jacktrip_receive_2 = self.jacktrip_receive(jacktrip_ports[1])
+        jacktrip_send_1 = self.jacktrip_send(jacktrip_ports[0])
+        jacktrip_send_2 = self.jacktrip_send(jacktrip_ports[1])
+
+        self.connections.append((jacktrip_receive_1, jacktrip_send_2))
+        self.connections.append((jacktrip_receive_2, jacktrip_send_1))
+        self.connections.append((jacktrip_receive_1, self.ladspa_send(ladspa_ports[0])))
+        self.connections.append((jacktrip_receive_2, self.ladspa_send(ladspa_ports[1])))
+
     def set_all_connections(self, jacktrip_ports, ladspa_ports):
-        """make list of all connections between JackTrip clients & ladspa ports"""
-        for i, ladspa in enumerate(ladspa_ports):
-            jacktrip_receive = self.jacktrip_receive(jacktrip_ports[i])
-            ladspa_send = self.ladspa_send(ladspa)
-            self.connections.append((jacktrip_receive, ladspa_send))
-            for jacktrip_port in jacktrip_ports:
-                if jacktrip_port == jacktrip_ports[i]:
-                    continue
-                ladspa_receive = self.ladspa_receive(ladspa)
-                jacktrip_send = self.jacktrip_send(jacktrip_port)
-                self.connections.append((ladspa_receive, jacktrip_send))
+        """append all connections between JackTrip clients & ladspa ports"""
+
+        if len(jacktrip_ports) == 2:
+            self.set_connections_2_clients(jacktrip_ports, ladspa_ports)
+
+        if len(jacktrip_ports) > 3:
+            for i, ladspa in enumerate(ladspa_ports):
+                jacktrip_receive = self.jacktrip_receive(jacktrip_ports[i])
+                ladspa_send = self.ladspa_send(ladspa)
+                self.connections.append((jacktrip_receive, ladspa_send))
+                for jacktrip_port in jacktrip_ports:
+                    if jacktrip_port == jacktrip_ports[i]:
+                        continue
+                    ladspa_receive = self.ladspa_receive(ladspa)
+                    jacktrip_send = self.jacktrip_send(jacktrip_port)
+                    self.connections.append((ladspa_receive, jacktrip_send))
 
     def make_all_connections(self):
         if self.dry_run:

--- a/jack_client_patching.py
+++ b/jack_client_patching.py
@@ -166,69 +166,12 @@ class JackClientPatching:
 
         self.connect_ports(mpg123 + ":.*", send + ":send_.*")
 
-    def connect_to_left(self, receive, send):
-        """connect receive port/s to left send"""
-        if self.dry_run:
-            print("Connect left", receive, "to", send)
-            return
-
-        self.connect_ports(receive + ":receive_.*", send + ":send_1")
-
-    def connect_to_right(self, receive, send):
-        """connect receive port/s to right send"""
-        if self.dry_run:
-            print("Connect right", receive, "to", send)
-            return
-
-        self.connect_ports(receive + ":receive_.*", send + ":send_.*")
-
-    def connect_to_ladspa(self, receive, ladspa):
-        """connect receive port/s to a ladspa plugin"""
-        if self.dry_run:
-            print("Connect to ladspa", receive, "to", ladspa)
-            return
-
-        self.connect_ports(receive + ":receive_.*", ladspa + ":Input.*")
-
-    def connect_from_ladspa(self, ladspa, send):
-        """connect a ladspa plugin to send port/s"""
-        if self.dry_run:
-            print("Connect from ladspa", ladspa, "to", send)
-            return
-
-        self.connect_ports(ladspa + ":Output.*", send + ":send_.*")
-
     def connect_darkice_to_centre(self, receive, send):
         if self.dry_run:
             print("Connect centre", receive, "to", send)
             return
 
         self.connect_ports(receive + ":receive_.*", send + ".*")
-
-    def connect_darkice_to_left(self, receive, send):
-
-        """connect pair of receive ports to the send ports, left panned"""
-        if self.dry_run:
-            print("Connect left", receive, "to", send)
-            return
-
-        self.connect_ports(receive + ":receive_.*", send + ":left")
-
-    def connect_darkice_to_right(self, receive, send):
-        """connect pair of receive ports to the send ports, right panned"""
-        if self.dry_run:
-            print("Connect right", receive, "to", send)
-            return
-
-        self.connect_ports(receive + ":receive_.*", send + ":right")
-
-    def connect_darkice_from_ladspa(self, ladspa, send):
-        """connect a ladspa plugin to a pair of send ports"""
-        if self.dry_run:
-            print("Connect from ladspa", ladspa, "to", send)
-            return
-
-        self.connect_ports(ladspa + ":Output.*", send + ".*")
 
     def connect_mpg123_to_darkice(self, mpg123, send):
         """connect an instance of mpg123-jack to a darkice client"""

--- a/jacktrip_pypatcher.py
+++ b/jacktrip_pypatcher.py
@@ -166,11 +166,8 @@ def autopatch(jackClient, dry_run, jacktrip_clients):
     if len(jacktrip_clients) >= 4 and len(jacktrip_clients) <= 11:
         ladspa_ports = ladspa.get_ports(len(jacktrip_clients), all_ladspa_ports)
         jcp.set_all_connections(jacktrip_clients, ladspa_ports)
+        jcp.set_darkice_connections(ladspa_ports, darkice_port)
         jcp.make_all_connections()
-
-        print("-- darkice --")
-        for ladspa_port in ladspa_ports:
-            jcp.connect_darkice_from_ladspa(ladspa_port, darkice_port)
 
     if len(jacktrip_clients) > 11:
         print("Not yet implemented")

--- a/jacktrip_pypatcher.py
+++ b/jacktrip_pypatcher.py
@@ -123,36 +123,11 @@ def autopatch(jackClient, dry_run, jacktrip_clients):
         jcp.make_all_connections()
 
     if len(jacktrip_clients) == 3:
-        # Connections for 3 clients are a bit special as we need to make sure the L-R
-        # balance for each client is even (not two peers in one channel)
-        panning_positions = ladspa.get_panning_positions(len(jacktrip_clients))
 
-        # ports needed for 2 & 3 client sessions
-        # if we like this method we can add the positions to all_panning_positions
-        ladspa_mid_left_1 = ladspa.get_port(panning_positions[0], all_ladspa_ports)
-        ladspa_mid_right_1 = ladspa.get_port(panning_positions[1], all_ladspa_ports)
-        ladspa_mid_left_2 = ladspa.get_port(panning_positions[2], all_ladspa_ports)
-        ladspa_mid_right_2 = ladspa.get_port(panning_positions[3], all_ladspa_ports)
-
-        jcp.connect_to_ladspa(jacktrip_clients[1], ladspa_mid_left_1)
-        jcp.connect_to_ladspa(jacktrip_clients[1], ladspa_mid_right_1)
-        jcp.connect_to_ladspa(jacktrip_clients[0], ladspa_mid_left_2)
-        jcp.connect_to_ladspa(jacktrip_clients[2], ladspa_mid_right_2)
-
-        jcp.connect_from_ladspa(ladspa_mid_left_1, jacktrip_clients[0])
-        jcp.connect_from_ladspa(ladspa_mid_right_2, jacktrip_clients[0])
-
-        jcp.connect_from_ladspa(ladspa_mid_left_2, jacktrip_clients[1])
-        jcp.connect_from_ladspa(ladspa_mid_right_2, jacktrip_clients[1])
-
-        jcp.connect_from_ladspa(ladspa_mid_left_2, jacktrip_clients[2])
-        jcp.connect_from_ladspa(ladspa_mid_right_1, jacktrip_clients[2])
-
-        print("-- darkice --")
-
-        jcp.connect_darkice_from_ladspa(ladspa_mid_left_2, darkice_port)
-        jcp.connect_darkice_from_ladspa(ladspa_mid_right_2, darkice_port)
-        jcp.connect_darkice_to_centre(jacktrip_clients[1], darkice_port)
+        ladspa_ports = ladspa.get_ports(len(jacktrip_clients), all_ladspa_ports)
+        jcp.set_all_connections(jacktrip_clients, ladspa_ports)
+        jcp.set_darkice_connections([ladspa_ports[0]] + ladspa_ports[3:], darkice_port)
+        jcp.make_all_connections()
 
     if len(jacktrip_clients) >= 4 and len(jacktrip_clients) <= 11:
         ladspa_ports = ladspa.get_ports(len(jacktrip_clients), all_ladspa_ports)

--- a/jacktrip_pypatcher.py
+++ b/jacktrip_pypatcher.py
@@ -116,23 +116,16 @@ def autopatch(jackClient, dry_run, jacktrip_clients):
         jcp.connect_mpg123_to_darkice(lounge_music.port, darkice_port)
         jcp.connect_darkice_to_centre(jacktrip_clients[0], darkice_port)
 
-    if len(jacktrip_clients) == 2:
-        ladspa_ports = ladspa.get_ports(len(jacktrip_clients), all_ladspa_ports)
-        jcp.set_all_connections(jacktrip_clients, ladspa_ports)
-        jcp.set_darkice_connections(ladspa_ports, darkice_port)
-        jcp.make_all_connections()
-
-    if len(jacktrip_clients) == 3:
+    if len(jacktrip_clients) >= 2 and len(jacktrip_clients) <= 11:
 
         ladspa_ports = ladspa.get_ports(len(jacktrip_clients), all_ladspa_ports)
-        jcp.set_all_connections(jacktrip_clients, ladspa_ports)
-        jcp.set_darkice_connections([ladspa_ports[0]] + ladspa_ports[3:], darkice_port)
-        jcp.make_all_connections()
+        darkice_ladspa_ports = ladspa_ports
 
-    if len(jacktrip_clients) >= 4 and len(jacktrip_clients) <= 11:
-        ladspa_ports = ladspa.get_ports(len(jacktrip_clients), all_ladspa_ports)
+        if len(jacktrip_clients) == 3:
+            darkice_ladspa_ports = [ladspa_ports[0]] + ladspa_ports[3:]
+
         jcp.set_all_connections(jacktrip_clients, ladspa_ports)
-        jcp.set_darkice_connections(ladspa_ports, darkice_port)
+        jcp.set_darkice_connections(darkice_ladspa_ports, darkice_port)
         jcp.make_all_connections()
 
     if len(jacktrip_clients) > 11:

--- a/jacktrip_pypatcher.py
+++ b/jacktrip_pypatcher.py
@@ -116,8 +116,15 @@ def autopatch(jackClient, dry_run, jacktrip_clients):
         jcp.connect_mpg123_to_darkice(lounge_music.port, darkice_port)
         jcp.connect_darkice_to_centre(jacktrip_clients[0], darkice_port)
 
-    if len(jacktrip_clients) == 2 or len(jacktrip_clients) == 3:
+    if len(jacktrip_clients) == 2:
+        ladspa_ports = ladspa.get_ports(len(jacktrip_clients), all_ladspa_ports)
+        jcp.set_all_connections(jacktrip_clients, ladspa_ports)
+        jcp.set_darkice_connections(ladspa_ports, darkice_port)
+        jcp.make_all_connections()
 
+    if len(jacktrip_clients) == 3:
+        # Connections for 3 clients are a bit special as we need to make sure the L-R
+        # balance for each client is even (not two peers in one channel)
         panning_positions = ladspa.get_panning_positions(len(jacktrip_clients))
 
         # ports needed for 2 & 3 client sessions
@@ -126,22 +133,6 @@ def autopatch(jackClient, dry_run, jacktrip_clients):
         ladspa_mid_right_1 = ladspa.get_port(panning_positions[1], all_ladspa_ports)
         ladspa_mid_left_2 = ladspa.get_port(panning_positions[2], all_ladspa_ports)
         ladspa_mid_right_2 = ladspa.get_port(panning_positions[3], all_ladspa_ports)
-
-    if len(jacktrip_clients) == 2:
-
-        jcp.connect_to_centre(jacktrip_clients[1], jacktrip_clients[0])
-        jcp.connect_to_centre(jacktrip_clients[0], jacktrip_clients[1])
-
-        print("-- darkice --")
-        jcp.connect_to_ladspa(jacktrip_clients[0], ladspa_mid_left_1)
-        jcp.connect_to_ladspa(jacktrip_clients[1], ladspa_mid_right_2)
-
-        jcp.connect_darkice_from_ladspa(ladspa_mid_left_1, darkice_port)
-        jcp.connect_darkice_from_ladspa(ladspa_mid_right_2, darkice_port)
-
-    if len(jacktrip_clients) == 3:
-        # Connections for 3 clients are a bit special as we need to make sure the L-R
-        # balance for each client is even (not two peers in one channel)
 
         jcp.connect_to_ladspa(jacktrip_clients[1], ladspa_mid_left_1)
         jcp.connect_to_ladspa(jacktrip_clients[1], ladspa_mid_right_1)

--- a/ladspa_plugins.py
+++ b/ladspa_plugins.py
@@ -13,7 +13,9 @@ class LadspaPlugins(object):
         self.dry_run = dry_run
 
     def get_panning_positions(self, number_of_clients):
-        if number_of_clients == 2 or number_of_clients == 3:
+        if number_of_clients == 2:
+            return self.all_positions[5:7]
+        if number_of_clients == 3:
             return [
                 self.all_positions[5],
                 self.all_positions[6],

--- a/ladspa_plugins.py
+++ b/ladspa_plugins.py
@@ -17,6 +17,7 @@ class LadspaPlugins(object):
             return self.all_positions[5:7]
         if number_of_clients == 3:
             return [
+                self.all_positions[0],
                 self.all_positions[5],
                 self.all_positions[6],
                 (self.all_positions[5] - 0.01),

--- a/test_jack_client_patching.py
+++ b/test_jack_client_patching.py
@@ -1,10 +1,9 @@
 import jack_client_patching as p
 import pytest
-
-
 import jack_client_patching as p
 
-def test_jacktrip_connections_2_clients():
+
+def test_set_jacktrip_connections_2_clients():
 
     jackClient = None
     jacktrip_clients = [
@@ -28,7 +27,8 @@ def test_jacktrip_connections_2_clients():
 
     assert jcp.connections == connections
 
-def test_darkice_connections_2_clients():
+
+def test_set_darkice_connections_2_clients():
 
     jackClient = None
     ladspa_ports = [
@@ -48,7 +48,8 @@ def test_darkice_connections_2_clients():
 
     assert jcp.connections == connections
 
-def test_darkice_connections_2_clients():
+
+def test_set_all_connections_2_clients():
 
     jackClient = None
     jacktrip_clients = [
@@ -78,7 +79,7 @@ def test_darkice_connections_2_clients():
     assert jcp.connections == connections
 
 
-def test_jacktrip_connections():
+def test_set_jacktrip_connections_4_clients():
 
     jackClient = None
     jacktrip_clients = [
@@ -119,7 +120,7 @@ def test_jacktrip_connections():
     assert jcp.connections == connections
 
 
-def test_darkice_connections():
+def test_set_darkice_connections_4_clients():
 
     jackClient = None
 
@@ -145,7 +146,7 @@ def test_darkice_connections():
     assert jcp.connections == connections
 
 
-def test_all_connections():
+def test_set_all_connections_4_clients():
 
     jackClient = None
     jacktrip_clients = [
@@ -189,6 +190,83 @@ def test_all_connections():
     jcp = p.JackClientPatching(jackClient, dry_run=True)
     jcp.set_all_connections(jacktrip_clients, ladspa_ports)
     jcp.set_darkice_connections(ladspa_ports, darkice_port)
+
+    assert jcp.connections == connections
+
+
+def test_set_jacktrip_connections_3_clients():
+
+    jackClient = None
+    jacktrip_clients = [
+        "..ffff.192.168.0.1",
+        "..ffff.192.168.0.2",
+        "..ffff.192.168.0.3",
+    ]
+    ladspa_ports = [
+        "ladspa-centre",
+        "ladspa-left-45",
+        "ladspa-right-45",
+        "ladspa-left-46",
+        "ladspa-right-46",
+    ]
+
+    ladspa_ports = [
+        "ladspa-centre",
+        "ladspa-left-45",
+        "ladspa-right-45",
+        "ladspa-left-46",
+        "ladspa-right-46",
+    ]
+
+    connections = [
+        ("..ffff.192.168.0.1:receive_.*", "ladspa-centre:Input.*"),
+        ("..ffff.192.168.0.1:receive_.*", "ladspa-left-45:Input.*"),
+        ("..ffff.192.168.0.1:receive_.*", "ladspa-right-45:Input.*"),
+        ("..ffff.192.168.0.2:receive_.*", "ladspa-left-46:Input.*"),
+        ("..ffff.192.168.0.3:receive_.*", "ladspa-right-46:Input.*"),
+        ("ladspa-left-46:Output.*", "..ffff.192.168.0.1:send_.*"),
+        ("ladspa-right-46:Output.*", "..ffff.192.168.0.1:send_.*"),
+        ("ladspa-left-45:Output.*", "..ffff.192.168.0.2:send_.*"),
+        ("ladspa-right-46:Output.*", "..ffff.192.168.0.2:send_.*"),
+        ("ladspa-left-46:Output.*", "..ffff.192.168.0.3:send_.*"),
+        ("ladspa-right-45:Output.*", "..ffff.192.168.0.3:send_.*"),
+    ]
+
+    jcp = p.JackClientPatching(jackClient, dry_run=True)
+    jcp.set_all_connections(jacktrip_clients, ladspa_ports)
+
+    assert jcp.connections == connections
+
+
+def test_set_darkice_connections_3_clients():
+
+    jackClient = None
+    ladspa_ports = [
+        "ladspa-centre",
+        "ladspa-left-45",
+        "ladspa-right-45",
+        "ladspa-left-46",
+        "ladspa-right-46",
+    ]
+
+    ladspa_ports = [
+        "ladspa-centre",
+        "ladspa-left-45",
+        "ladspa-right-45",
+        "ladspa-left-46",
+        "ladspa-right-46",
+    ]
+
+    darkice_port = "darkice"
+
+    connections = [
+        ("ladspa-centre:Output.*", "darkice.*"),
+        ("ladspa-left-46:Output.*", "darkice.*"),
+        ("ladspa-right-46:Output.*", "darkice.*"),
+    ]
+
+    jcp = p.JackClientPatching(jackClient, dry_run=True)
+    jcp.set_darkice_connections([ladspa_ports[0]] + ladspa_ports[3:], darkice_port)
 
     assert jcp.connections == connections
 

--- a/test_jack_client_patching.py
+++ b/test_jack_client_patching.py
@@ -4,6 +4,79 @@ import pytest
 
 import jack_client_patching as p
 
+def test_jacktrip_connections_2_clients():
+
+    jackClient = None
+    jacktrip_clients = [
+        "..ffff.192.168.0.1",
+        "..ffff.192.168.0.2",
+    ]
+    ladspa_ports = [
+        "ladspa-left-45",
+        "ladspa-right-45",
+    ]
+
+    connections = [
+        ("..ffff.192.168.0.1:receive_.*", "..ffff.192.168.0.2:send_.*"),
+        ("..ffff.192.168.0.2:receive_.*", "..ffff.192.168.0.1:send_.*"),
+        ("..ffff.192.168.0.1:receive_.*", "ladspa-left-45:Input.*"),
+        ("..ffff.192.168.0.2:receive_.*", "ladspa-right-45:Input.*"),
+    ]
+
+    jcp = p.JackClientPatching(jackClient, dry_run=True)
+    jcp.set_all_connections(jacktrip_clients, ladspa_ports)
+
+    assert jcp.connections == connections
+
+def test_darkice_connections_2_clients():
+
+    jackClient = None
+    ladspa_ports = [
+        "ladspa-left-45",
+        "ladspa-right-45",
+    ]
+
+    darkice_port = "darkice"
+
+    connections = [
+        ("ladspa-left-45:Output.*", "darkice.*"),
+        ("ladspa-right-45:Output.*", "darkice.*"),
+    ]
+
+    jcp = p.JackClientPatching(jackClient, dry_run=True)
+    jcp.set_darkice_connections(ladspa_ports, darkice_port)
+
+    assert jcp.connections == connections
+
+def test_darkice_connections_2_clients():
+
+    jackClient = None
+    jacktrip_clients = [
+        "..ffff.192.168.0.1",
+        "..ffff.192.168.0.2",
+    ]
+    ladspa_ports = [
+        "ladspa-left-45",
+        "ladspa-right-45",
+    ]
+
+    darkice_port = "darkice"
+
+    connections = [
+        ("..ffff.192.168.0.1:receive_.*", "..ffff.192.168.0.2:send_.*"),
+        ("..ffff.192.168.0.2:receive_.*", "..ffff.192.168.0.1:send_.*"),
+        ("..ffff.192.168.0.1:receive_.*", "ladspa-left-45:Input.*"),
+        ("..ffff.192.168.0.2:receive_.*", "ladspa-right-45:Input.*"),
+        ("ladspa-left-45:Output.*", "darkice.*"),
+        ("ladspa-right-45:Output.*", "darkice.*"),
+    ]
+
+    jcp = p.JackClientPatching(jackClient, dry_run=True)
+    jcp.set_all_connections(jacktrip_clients, ladspa_ports)
+    jcp.set_darkice_connections(ladspa_ports, darkice_port)
+
+    assert jcp.connections == connections
+
 
 def test_jacktrip_connections():
 

--- a/test_jack_client_patching.py
+++ b/test_jack_client_patching.py
@@ -2,7 +2,10 @@ import jack_client_patching as p
 import pytest
 
 
-def test_set_all_connections():
+import jack_client_patching as p
+
+
+def test_jacktrip_connections():
 
     jackClient = None
     jacktrip_clients = [
@@ -39,6 +42,80 @@ def test_set_all_connections():
 
     jcp = p.JackClientPatching(jackClient, dry_run=True)
     jcp.set_all_connections(jacktrip_clients, ladspa_ports)
+
+    assert jcp.connections == connections
+
+
+def test_darkice_connections():
+
+    jackClient = None
+
+    ladspa_ports = [
+        "ladspa-left-30",
+        "ladspa-right-30",
+        "ladspa-left-60",
+        "ladspa-right-60",
+    ]
+
+    darkice_port = "darkice"
+
+    connections = [
+        ("ladspa-left-30:Output.*", "darkice.*"),
+        ("ladspa-right-30:Output.*", "darkice.*"),
+        ("ladspa-left-60:Output.*", "darkice.*"),
+        ("ladspa-right-60:Output.*", "darkice.*"),
+    ]
+
+    jcp = p.JackClientPatching(jackClient, dry_run=True)
+    jcp.set_darkice_connections(ladspa_ports, darkice_port)
+
+    assert jcp.connections == connections
+
+
+def test_all_connections():
+
+    jackClient = None
+    jacktrip_clients = [
+        "..ffff.192.168.0.1",
+        "..ffff.192.168.0.2",
+        "..ffff.192.168.0.3",
+        "..ffff.192.168.0.4",
+    ]
+    ladspa_ports = [
+        "ladspa-left-30",
+        "ladspa-right-30",
+        "ladspa-left-60",
+        "ladspa-right-60",
+    ]
+
+    darkice_port = "darkice"
+
+    connections = [
+        ("..ffff.192.168.0.1:receive_.*", "ladspa-left-30:Input.*"),
+        ("ladspa-left-30:Output.*", "..ffff.192.168.0.2:send_.*"),
+        ("ladspa-left-30:Output.*", "..ffff.192.168.0.3:send_.*"),
+        ("ladspa-left-30:Output.*", "..ffff.192.168.0.4:send_.*"),
+        ("..ffff.192.168.0.2:receive_.*", "ladspa-right-30:Input.*"),
+        ("ladspa-right-30:Output.*", "..ffff.192.168.0.1:send_.*"),
+        ("ladspa-right-30:Output.*", "..ffff.192.168.0.3:send_.*"),
+        ("ladspa-right-30:Output.*", "..ffff.192.168.0.4:send_.*"),
+        ("..ffff.192.168.0.3:receive_.*", "ladspa-left-60:Input.*"),
+        ("ladspa-left-60:Output.*", "..ffff.192.168.0.1:send_.*"),
+        ("ladspa-left-60:Output.*", "..ffff.192.168.0.2:send_.*"),
+        ("ladspa-left-60:Output.*", "..ffff.192.168.0.4:send_.*"),
+        ("..ffff.192.168.0.4:receive_.*", "ladspa-right-60:Input.*"),
+        ("ladspa-right-60:Output.*", "..ffff.192.168.0.1:send_.*"),
+        ("ladspa-right-60:Output.*", "..ffff.192.168.0.2:send_.*"),
+        ("ladspa-right-60:Output.*", "..ffff.192.168.0.3:send_.*"),
+        ("ladspa-left-30:Output.*", "darkice.*"),
+        ("ladspa-right-30:Output.*", "darkice.*"),
+        ("ladspa-left-60:Output.*", "darkice.*"),
+        ("ladspa-right-60:Output.*", "darkice.*"),
+    ]
+
+    jcp = p.JackClientPatching(jackClient, dry_run=True)
+    jcp.set_all_connections(jacktrip_clients, ladspa_ports)
+    jcp.set_darkice_connections(ladspa_ports, darkice_port)
 
     assert jcp.connections == connections
 

--- a/test_jack_client_patching.py
+++ b/test_jack_client_patching.py
@@ -194,7 +194,6 @@ def test_all_connections():
 
 
 def test_set_all_connections_3_clients():
-    pytest.xfail("This configuration not currently supported")
 
     jackClient = None
     jacktrip_clients = [
@@ -203,26 +202,42 @@ def test_set_all_connections_3_clients():
         "..ffff.192.168.0.3",
     ]
     ladspa_ports = [
+        "ladspa-centre",
         "ladspa-left-45",
         "ladspa-right-45",
         "ladspa-left-46",
         "ladspa-right-46",
     ]
 
+    ladspa_ports = [
+        "ladspa-centre",
+        "ladspa-left-45",
+        "ladspa-right-45",
+        "ladspa-left-46",
+        "ladspa-right-46",
+    ]
+
+    darkice_port = "darkice"
+
     connections = [
+        ("..ffff.192.168.0.1:receive_.*", "ladspa-centre:Input.*"),
         ("..ffff.192.168.0.1:receive_.*", "ladspa-left-45:Input.*"),
-        ("ladspa-left-46:Output.*", "..ffff.192.168.0.1:send_.*"),
-        ("ladspa-right-45:Output.*", "..ffff.192.168.0.1:send_.*"),
+        ("..ffff.192.168.0.1:receive_.*", "ladspa-right-45:Input.*"),
         ("..ffff.192.168.0.2:receive_.*", "ladspa-left-46:Input.*"),
-        ("..ffff.192.168.0.2:receive_.*", "ladspa-right-46:Input.*"),
+        ("..ffff.192.168.0.3:receive_.*", "ladspa-right-46:Input.*"),
+        ("ladspa-left-46:Output.*", "..ffff.192.168.0.1:send_.*"),
+        ("ladspa-right-46:Output.*", "..ffff.192.168.0.1:send_.*"),
         ("ladspa-left-45:Output.*", "..ffff.192.168.0.2:send_.*"),
-        ("ladspa-right-45:Output.*", "..ffff.192.168.0.2:send_.*"),
-        ("..ffff.192.168.0.3:receive_.*", "ladspa-right-45:Input.*"),
-        ("ladspa-left-45:Output.*", "..ffff.192.168.0.3:send_.*"),
-        ("ladspa-right-46:Output.*", "..ffff.192.168.0.3:send_.*"),
+        ("ladspa-right-46:Output.*", "..ffff.192.168.0.2:send_.*"),
+        ("ladspa-left-46:Output.*", "..ffff.192.168.0.3:send_.*"),
+        ("ladspa-right-45:Output.*", "..ffff.192.168.0.3:send_.*"),
+        ("ladspa-centre:Output.*", "darkice.*"),
+        ("ladspa-left-46:Output.*", "darkice.*"),
+        ("ladspa-right-46:Output.*", "darkice.*"),
     ]
 
     jcp = p.JackClientPatching(jackClient, dry_run=True)
     jcp.set_all_connections(jacktrip_clients, ladspa_ports)
+    jcp.set_darkice_connections([ladspa_ports[0]] + ladspa_ports[3:], darkice_port)
 
     assert jcp.connections == connections

--- a/test_jack_client_patching.py
+++ b/test_jack_client_patching.py
@@ -1,6 +1,4 @@
 import jack_client_patching as p
-import pytest
-import jack_client_patching as p
 
 
 def test_set_jacktrip_connections_2_clients():

--- a/test_ladspa_plugins.py
+++ b/test_ladspa_plugins.py
@@ -55,7 +55,8 @@ def test_get_panning_positions():
         None, "/home/sam/ng-jackspa/jackspa-cli", all_panning_positions, dry_run=True
     )
 
-    positions_for_2_3_clients = [-0.45, 0.45, -0.46, 0.46]
+    positions_for_2_clients = [-0.45, 0.45]
+    positions_for_3_clients = [-0.45, 0.45, -0.46, 0.46]
     positions_for_4_clients = [-0.3, 0.3, -0.45, 0.45]
     positions_for_5_clients = [0, -0.3, 0.3, -0.45, 0.45]
     positions_for_6_clients = [-0.15, 0.15, -0.45, 0.45, -0.6, 0.6]
@@ -88,8 +89,8 @@ def test_get_panning_positions():
         0.75,
     ]
 
-    assert ladspa.get_panning_positions(2) == positions_for_2_3_clients
-    assert ladspa.get_panning_positions(3) == positions_for_2_3_clients
+    assert ladspa.get_panning_positions(2) == positions_for_2_clients
+    assert ladspa.get_panning_positions(3) == positions_for_3_clients
     assert ladspa.get_panning_positions(4) == positions_for_4_clients
     assert ladspa.get_panning_positions(5) == positions_for_5_clients
     assert ladspa.get_panning_positions(6) == positions_for_6_clients

--- a/test_ladspa_plugins.py
+++ b/test_ladspa_plugins.py
@@ -56,7 +56,7 @@ def test_get_panning_positions():
     )
 
     positions_for_2_clients = [-0.45, 0.45]
-    positions_for_3_clients = [-0.45, 0.45, -0.46, 0.46]
+    positions_for_3_clients = [0, -0.45, 0.45, -0.46, 0.46]
     positions_for_4_clients = [-0.3, 0.3, -0.45, 0.45]
     positions_for_5_clients = [0, -0.3, 0.3, -0.45, 0.45]
     positions_for_6_clients = [-0.15, 0.15, -0.45, 0.45, -0.6, 0.6]


### PR DESCRIPTION
- use different ladspa port lists for 2 & 3 clients
- add `ladspa-centre` plugin for 3 clients to make darkice connections uniform
- move logic for making 2 & 3 client connections into `jcp`
- lots of tests..... (this could be done more efficiently probably)

(sorry this PR is a bit bigger than the recent slim ones...)