### PR TITLE
Change filename and path for recordings

### DIFF
--- a/stereo_recording.py
+++ b/stereo_recording.py
@@ -3,6 +3,7 @@
 # import jack
 import psutil
 import subprocess
+from datetime import datetime
 
 
 class StereoRecording(object):
@@ -13,11 +14,18 @@ class StereoRecording(object):
         self.recording_path_prefix = recording_path_prefix
         self.dry_run = dry_run
 
+    def get_time_string(self):
+        return datetime.now().strftime("%Y_%m_%d_%H%M")
+
+    def get_filename_prefix(self):
+        time = self.get_time_string()
+        return self.recording_path_prefix + time + "-"
+
     def generate_subprocess_cmd(self):
         return [
             "jack_capture",
             "--filename-prefix",
-            self.recording_path_prefix,
+            self.get_filename_prefix(),
             "-S",
             "--channels",
             "2",

--- a/test_stereo_recording.py
+++ b/test_stereo_recording.py
@@ -1,13 +1,25 @@
+from unittest.mock import Mock
 from stereo_recording import StereoRecording
 
+def test_get_filename_prefix():
+    stereo_recording = StereoRecording("/home/sam/recordings/audio/", dry_run=True)
+    mock = Mock()
+    mock.return_value = "2020_10_15_1254"
+    stereo_recording.get_time_string = mock
+    filename_prefix = "/home/sam/recordings/audio/2020_10_15_1254-"
+    assert stereo_recording.get_filename_prefix() == filename_prefix
 
 def test_generate_subprocess_cmd():
 
-    stereo_recording = StereoRecording("/home/sam/darkice-", dry_run=True)
+    stereo_recording = StereoRecording("/home/sam/recordings/audio/", dry_run=True)
+    mock = Mock()
+    mock.return_value = "2020_10_15_1254"
+    stereo_recording.get_time_string = mock
+
     cmd = [
         "jack_capture",
         "--filename-prefix",
-        "/home/sam/darkice-",
+        "/home/sam/recordings/audio/2020_10_15_1254-",
         "-S",
         "--channels",
         "2",

--- a/test_stereo_recording.py
+++ b/test_stereo_recording.py
@@ -1,6 +1,7 @@
 from unittest.mock import Mock
 from stereo_recording import StereoRecording
 
+
 def test_get_filename_prefix():
     stereo_recording = StereoRecording("/home/sam/recordings/audio/", dry_run=True)
     mock = Mock()
@@ -8,6 +9,7 @@ def test_get_filename_prefix():
     stereo_recording.get_time_string = mock
     filename_prefix = "/home/sam/recordings/audio/2020_10_15_1254-"
     assert stereo_recording.get_filename_prefix() == filename_prefix
+
 
 def test_generate_subprocess_cmd():
 


### PR DESCRIPTION
I'm starting to upload the recordings to our cloud storage, a couple of small changes here:

- store recordings in dedicated folder `home/sam/recordings/audio`
- name the files with date and time strings `2020_11_05_1749_darckice-01`