### PR TITLE
Install jackspa-cli into /usr/local/bin

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,10 @@ $ sudo aptitude install invada-studio-plugins-ladspa
 $ git clone https://repo.or.cz/ng-jackspa.git
 $ sudo aptitude install libglib2.0-dev libncurses5-dev ladspa-sdk ladspa-sdk-dev
 $ cd ng-jackspa
-# trying to avoid building the GTK version...!
+# trying to avoid building the GTK version, so avoid make install...!
 $ make njackspa jackspa-cli
-$ ./njackspa /usr/lib/ladspa/inv_input.so 3301
+$ cp njackspa jackspa-cli /usr/local/bin/
+$ njackspa /usr/lib/ladspa/inv_input.so 3301
 ```
 
 ### Python dependencies

--- a/jacktrip_pypatcher.py
+++ b/jacktrip_pypatcher.py
@@ -50,7 +50,7 @@ def autopatch(jackClient, dry_run, jacktrip_clients):
         -0.75,
         0.75,
     ]
-    jackspa_path = "/home/sam/ng-jackspa/jackspa-cli"
+    jackspa_path = "jackspa-cli"
     lounge_music_path = "/home/sam/lounge-music.mp3"
     recording_path_prefix = "/home/sam/darkice-"
 

--- a/test_ladspa_plugins.py
+++ b/test_ladspa_plugins.py
@@ -4,10 +4,10 @@ from unittest.mock import Mock
 
 def test_generate_subprocess_cmd(position=0.3):
 
-    ladspa = LadspaPlugins(None, "/home/sam/ng-jackspa/jackspa-cli", [], dry_run=True)
+    ladspa = LadspaPlugins(None, "jackspa-cli", [], dry_run=True)
 
     cmd = [
-        "/home/sam/ng-jackspa/jackspa-cli",
+        "jackspa-cli",
         "-j",
         "ladspa-right-30",
         "-i",
@@ -21,7 +21,7 @@ def test_generate_subprocess_cmd(position=0.3):
 
 def test_generate_port_name():
 
-    ladspa = LadspaPlugins(None, "/home/sam/ng-jackspa/jackspa-cli", [], dry_run=True)
+    ladspa = LadspaPlugins(None, "jackspa-cli", [], dry_run=True)
     panning_positions = [0, -0.3, 0.3, -0.6, 0.6]
     port_names = [
         "ladspa-centre",
@@ -52,7 +52,7 @@ def test_get_panning_positions():
         0.75,
     ]
     ladspa = LadspaPlugins(
-        None, "/home/sam/ng-jackspa/jackspa-cli", all_panning_positions, dry_run=True
+        None, "jackspa-cli", all_panning_positions, dry_run=True
     )
 
     positions_for_2_clients = [-0.45, 0.45]
@@ -103,7 +103,7 @@ def test_get_panning_positions():
 
 # run pytest with -rP flag to see stdout logs showing which ports need to be started
 def test_get_and_check_port():
-    ladspa = LadspaPlugins(None, "/home/sam/ng-jackspa/jackspa-cli", [], dry_run=True)
+    ladspa = LadspaPlugins(None, "jackspa-cli", [], dry_run=True)
     panning_positions = [0, -0.3, 0.3, -0.6, 0.6]
     all_existing_ladspa_ports = [Mock()]
     all_existing_ladspa_ports[0].name = "ladspa-centre"
@@ -138,7 +138,7 @@ def test_get_ports():
         0.75,
     ]
     ladspa = LadspaPlugins(
-        None, "/home/sam/ng-jackspa/jackspa-cli", all_panning_positions, dry_run=True
+        None, "jackspa-cli", all_panning_positions, dry_run=True
     )
     no_of_clients = 4
 

--- a/test_ladspa_plugins.py
+++ b/test_ladspa_plugins.py
@@ -51,9 +51,7 @@ def test_get_panning_positions():
         -0.75,
         0.75,
     ]
-    ladspa = LadspaPlugins(
-        None, "jackspa-cli", all_panning_positions, dry_run=True
-    )
+    ladspa = LadspaPlugins(None, "jackspa-cli", all_panning_positions, dry_run=True)
 
     positions_for_2_clients = [-0.45, 0.45]
     positions_for_3_clients = [0, -0.45, 0.45, -0.46, 0.46]
@@ -137,9 +135,7 @@ def test_get_ports():
         -0.75,
         0.75,
     ]
-    ladspa = LadspaPlugins(
-        None, "jackspa-cli", all_panning_positions, dry_run=True
-    )
+    ladspa = LadspaPlugins(None, "jackspa-cli", all_panning_positions, dry_run=True)
     no_of_clients = 4
 
     all_existing_ladspa_ports = [


### PR DESCRIPTION
* this allows us to remove some hardwired use of `~sam`
* current servers will need to be updated as per the readme file to use this version, making this a breaking change & a "major" release according to Semver?
