### PR TITLE
Delay starting the patcher after being notified

### DIFF
--- a/patcher_watchgod.py
+++ b/patcher_watchgod.py
@@ -7,7 +7,7 @@ from watchgod import run_process
 def foobar():
     while True:
         try:
-            time.sleep(5)
+            time.sleep(2)
             jtp.main()
             time.sleep(6000)
         except Exception as e:

--- a/patcher_watchgod.py
+++ b/patcher_watchgod.py
@@ -7,6 +7,7 @@ from watchgod import run_process
 def foobar():
     while True:
         try:
+            time.sleep(5)
             jtp.main()
             time.sleep(6000)
         except Exception as e:


### PR DESCRIPTION
* this may allow clients that take a little bit longer to activate sufficient time to start
* fixes https://github.com/noiseorchestra/jacktrip_pypatcher/issues/89